### PR TITLE
[Add] アクティビティ機能の実装

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,0 +1,11 @@
+#header-activities {
+  width: 400px;
+  .dropdown-item {
+    max-width: initial;
+    font-size: 12px;
+  }
+
+  .read {
+    background: #f1f1f1;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
 @import 'swiper/swiper-bundle';
+@import 'header';
 
 @mixin box_sizing {
   -moz-box-sizing:    border-box;

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -1,7 +1,12 @@
 @import 'bootstrap-material-design/dist/css/bootstrap-material-design';
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
+@import 'header';
 
 main {
   padding-top: 50px;
+}
+
+.read {
+  background: #f1f1f1;
 }

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,9 @@
+class ActivitiesController < ApplicationController
+  before_action :require_login, only: %i[read]
+
+  def read
+    activity = current_user.activities.find(params[:id])
+    activity.read! if activity.unread?
+    redirect_to activity.redirect_path
+  end
+end

--- a/app/controllers/mypage/activities_controller.rb
+++ b/app/controllers/mypage/activities_controller.rb
@@ -1,0 +1,7 @@
+class Mypage::ActivitiesController < Mypage::BaseController
+  before_action :require_login, only: %i[index]
+
+  def index
+    @activities = current_user.activities.order(created_at: :desc).page(params[:page]).per(10)
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,43 @@
+# == Schema Information
+#
+# Table name: activities
+#
+#  id           :bigint           not null, primary key
+#  action_type  :integer          not null
+#  read         :boolean          default("unread"), not null
+#  subject_type :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  subject_id   :bigint
+#  user_id      :bigint
+#
+# Indexes
+#
+#  index_activities_on_subject_type_and_subject_id  (subject_type,subject_id)
+#  index_activities_on_user_id                      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Activity < ApplicationRecord
+  include Rails.application.routes.url_helpers
+  belongs_to :subject, polymorphic: true
+  belongs_to :user
+
+  scope :recent, ->(count) { order(created_at: :desc).limit(count) }
+
+  enum action_type: { commented_to_own_post: 0, liked_to_own_post: 1, followed_me: 2 }
+  enum read: { unread: false, read: true }
+
+  def redirect_path
+    case action_type.to_sym
+    when :commented_to_own_post
+      post_path(subject.post, anchor: "comment-#{subject.id}")
+    when :liked_to_own_post
+      post_path(subject.post)
+    when :followed_me
+      user_path(subject.follower)
+    end
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,6 +22,15 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  has_one :activity, as: :subject, dependent: :destroy
 
   validates :body, presence: true, length: { maximum: 1000 }
+
+  after_create_commit :create_activities
+
+  private
+
+  def create_activities
+    Activity.create(subject: self, user: post.user, action_type: :commented_to_own_post)
+  end
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -22,4 +22,15 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  has_one :activity, as: :subject, dependent: :destroy
+
+  validates :user_id, uniqueness: { scope: :post_id }
+
+  after_create_commit :create_activities
+
+  private
+
+  def create_activities
+    Activity.create(subject: self, user: post.user, action_type: :liked_to_own_post)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,7 @@ class User < ApplicationRecord
                                    dependent: :destroy
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
+  has_many :activities, dependent: :destroy
 
   scope :recent, ->(count) { order(created_at: :desc).limit(count) }
 

--- a/app/views/mypage/activities/_commented_to_own_post.html.slim
+++ b/app/views/mypage/activities/_commented_to_own_post.html.slim
@@ -1,0 +1,13 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.user.username, user_path(activity.subject.user)
+  | があなたの
+  object
+    = link_to '投稿', post_path(activity.subject.post)
+  | に
+  object
+    = link_to 'コメント', post_path(activity.subject.post, anchor: "comment-#{activity.subject.id}")
+  | しました
+  .text-right
+    = l activity.created_at, format: :short

--- a/app/views/mypage/activities/_followed_me.html.slim
+++ b/app/views/mypage/activities/_followed_me.html.slim
@@ -1,0 +1,7 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.follower.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.follower.username, user_path(activity.subject.follower)
+  | があなたをフォローしました
+  .text-right
+    = l activity.created_at, format: :short

--- a/app/views/mypage/activities/_liked_to_own_post.html.slim
+++ b/app/views/mypage/activities/_liked_to_own_post.html.slim
@@ -1,0 +1,10 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.user.username, user_path(activity.subject.user)
+  | があなたの
+  object
+    = link_to '投稿', post_path(activity.subject.post)
+  | にいいねしました
+  .text-right
+    = l activity.created_at, format: :short

--- a/app/views/mypage/activities/index.html.slim
+++ b/app/views/mypage/activities/index.html.slim
@@ -1,0 +1,8 @@
+- if @activities.present?
+  - @activities.each do |activity|
+    = render "#{activity.action_type}", activity: activity
+  = paginate @activities
+
+- else
+  .text-center
+    | お知らせはありません

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -3,3 +3,6 @@ nav
     li
       = link_to 'プロフィール編集', edit_mypage_account_path
       hr
+    li
+      = link_to '通知一覧', mypage_activities_path
+      hr

--- a/app/views/shared/_commented_to_own_post.html.slim
+++ b/app/views/shared/_commented_to_own_post.html.slim
@@ -1,0 +1,13 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.user.username, user_path(activity.subject.user)
+  | があなたの
+  object
+    = link_to '投稿', post_path(activity.subject.post)
+  | に
+  object
+    = link_to 'コメント', post_path(activity.subject.post, anchor: "comment-#{activity.subject.id}")
+  | しました
+  .ml-auto
+    = l activity.created_at, format: :short

--- a/app/views/shared/_followed_me.html.slim
+++ b/app/views/shared/_followed_me.html.slim
@@ -1,0 +1,7 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.follower.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.follower.username, user_path(activity.subject.follower)
+  | があなたをフォローしました
+  .ml-auto
+    = l activity.created_at, format: :short

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -9,8 +9,13 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         = link_to new_post_path, class: 'nav-link' do
           = icon 'far', 'image', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
-          = icon 'far', 'heart', class: 'fa-lg'
+        .dropdown
+          a#dropdownMenuButton.nav-link.position-relative href="#" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true"
+            = icon 'far', 'heart', class: 'fa-lg'
+            = render 'shared/unread_badge'
+          #header-activities.dropdown-menu.dropdown-menu-right.m-0.p-0 aria-labelledby="dropdownMenuButton"
+            = render 'shared/header_activities'
+
       li.nav-item
         = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'user', class: 'fa-lg'

--- a/app/views/shared/_header_activities.html.slim
+++ b/app/views/shared/_header_activities.html.slim
@@ -1,0 +1,8 @@
+- if current_user.activities.present?
+  - current_user.activities.recent(10).each do |activity|
+    = render "shared/#{activity.action_type}", activity: activity
+  - if current_user.activities.count > 10
+    = link_to 'すべてみる', mypage_activities_path, class: 'dropdown-item justify-content-center'
+- else
+  .dropdown-item
+    | お知らせはありません

--- a/app/views/shared/_liked_to_own_post.html.slim
+++ b/app/views/shared/_liked_to_own_post.html.slim
@@ -1,0 +1,10 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.user.username, user_path(activity.subject.user)
+  | があなたの
+  object
+    = link_to '投稿', post_path(activity.subject.post)
+  | にいいねしました
+  .ml-auto
+    = l activity.created_at, format: :short

--- a/app/views/shared/_unread_badge.html.slim
+++ b/app/views/shared/_unread_badge.html.slim
@@ -1,0 +1,3 @@
+- if current_user.activities.unread.count > 0
+  span.badge.badge-warning.navbar-badge.position-absolute style='top: 0; right:0;'
+    = current_user.activities.unread.count

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,8 @@ ja:
     id: 'ID'
     created_at: '作成日時'
     updated_at: '更新日時'
+  time:
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,13 @@ Rails.application.routes.draw do
   end
   resources :likes, only: %i[create destroy]
   resources :relationships, only: %i[create destroy]
+  resources :activities, only: [] do
+    patch :read, on: :member
+  end
 
   namespace :mypage do
     resource :account, only: %i[edit update]
+    resources :activities, only: %i[index]
   end
 
   get 'login', to: 'user_sessions#new'

--- a/db/migrate/20201005091247_create_activities.rb
+++ b/db/migrate/20201005091247_create_activities.rb
@@ -1,0 +1,12 @@
+class CreateActivities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :activities do |t|
+      t.references :subject, polymorphic: true
+      t.references :user, foreign_key: true
+      t.integer :action_type, null: false
+      t.boolean :read, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_02_112345) do
+ActiveRecord::Schema.define(version: 2020_10_05_091247) do
+
+  create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "subject_type"
+    t.bigint "subject_id"
+    t.bigint "user_id"
+    t.integer "action_type", null: false
+    t.boolean "read", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subject_type", "subject_id"], name: "index_activities_on_subject_type_and_subject_id"
+    t.index ["user_id"], name: "index_activities_on_user_id"
+  end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "body", null: false
@@ -63,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_10_02_112345) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "activities", "users"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"


### PR DESCRIPTION
## 概要
- 通知機能を実装
- タイミングと文言は以下の通り
  - フォローされたとき
    - xxx（リンク）があなたをフォローしました
    - 通知そのものに対してはxxxへのリンクを張る
  - 自分の投稿にいいねがあったとき
    - xxx（リンク）があなたの投稿（リンク）にいいねしました
    - 通知そのものに対しては投稿へのリンクを張る
  - 自分の投稿にコメントがあったとき
    - xxx（リンク）があなたの投稿（リンク）にコメント（リンク）しました
    - 通知そのものに対してはコメントへのリンクを張る（厳密には投稿ページに遷移し当該コメント部分にページ内ジャンプするイメージ）
- 既読判定も行う。通知一覧において、既読のものは薄暗い背景で、未読のものは白い背景で表示する
- 既読とするタイミングは各通知そのものをクリックした時とする
- 不自然ではあるが通知の元となったリソースが削除された際には通知自体も削除する仕様とする

##  補足
- ポリモーフィック関連を使うこと
- ヘッダー部分の通知リストには最新の10件しか表示させないこ と