### PR TITLE
Feature/17 direct messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'kaminari'
 gem 'config'
 gem 'sidekiq'
 gem 'sinatra'
+gem 'draper'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.2.3)
       activesupport (= 5.2.3)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (5.2.3)
       activemodel (= 5.2.3)
       activesupport (= 5.2.3)
@@ -87,6 +91,12 @@ GEM
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
+    draper (4.0.1)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
     dry-configurable (0.11.6)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
@@ -279,6 +289,8 @@ GEM
     redis-store (1.9.0)
       redis (>= 4, < 5)
     regexp_parser (1.7.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rexml (3.2.4)
     rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
@@ -404,6 +416,7 @@ DEPENDENCIES
   capybara
   carrierwave
   config
+  draper
   factory_bot_rails
   faker
   font-awesome-sass

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,3 +4,5 @@
 //= require bootstrap-material-design/dist/js/bootstrap-material-design.js
 //= require swiper/swiper-bundle.js
 //= require swiper.js
+//= require cable
+//= require cable/chatroom.js

--- a/app/assets/javascripts/cable/chatroom.js
+++ b/app/assets/javascripts/cable/chatroom.js
@@ -1,0 +1,42 @@
+$(function() {
+    if($("#chatroom").length > 0) {
+        const chatroomId = $("#chatroom").data("chatroomId")
+        const currentUserId = $("#chatroom").data("currentUserId")
+        App.chatrooms = App.cable.subscriptions.create({ channel: "ChatroomChannel", chatroom_id: chatroomId }, {
+            connected: function() {
+                console.log("connected")
+            },
+            disconnected: function() {
+                console.log("disconnected")
+            },
+            received: function(data) {
+                switch(data.type) {
+                    case "create":
+                        $('#message-box').append(data.html);
+                        // Vueなどを使えばもっとスマートにできる...
+                        if($(`#message-${data.message.id}`).data("senderId") != currentUserId) {
+                            // 自分の投稿じゃない場合は編集・削除ボタンを非表示にする
+                            $(`#message-${data.message.id}`).find('.crud-area').hide()
+                        }
+                        $('.input-message-body').val('');
+                        break;
+                    case "update":
+                        $(`#message-${data.message.id}`).replaceWith(data.html);
+                        // Vueなどを使えばもっとスマートにできる...
+                        if($(`#message-${data.message.id}`).data("senderId") != currentUserId) {
+                            // 自分の投稿じゃない場合は編集・削除ボタンを非表示にする
+                            $(`#message-${data.message.id}`).find('.crud-area').hide()
+                        }
+                        $("#message-edit-modal").modal('hide');
+                        break;
+                    case "delete":
+                        $(`#message-${data.message.id}`).remove();
+                        break;
+                }
+            },
+            speak: function() {
+                return this.perform('speak');
+              }
+        });
+    }
+})

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,19 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    private
+
+    def find_verified_user
+      if (verified_user = User.find_by(id: cookies.signed['user.id']))
+        verified_user
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/chatroom_channel.rb
+++ b/app/channels/chatroom_channel.rb
@@ -1,0 +1,9 @@
+class ChatroomChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "chatroom_#{params[:chatroom_id]}"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -1,0 +1,26 @@
+class ChatroomsController < ApplicationController
+  before_action :require_login, only: %i[index show create]
+  before_action :require_user_ids, only: %i[create]
+
+  def index
+    @chatrooms = current_user.chatrooms.includes(:users, messages: :user).page(params[:page]).order(created_at: :desc)
+  end
+
+  def create
+    users = User.where(id: params.dig(:chatroom, :user_ids)) + [current_user]
+    @chatroom = Chatroom.chatroom_for_users(users)
+    @messages = @chatroom.messages.order(created_at: :desc).limit(100).reverse
+    @chatroom_user = current_user.chatroom_users.find_by(chatroom_id: @chatroom.id)
+    redirect_to chatroom_path(@chatroom)
+  end
+
+  def show
+    @chatroom = current_user.chatrooms.includes(:users).find(params[:id])
+  end
+
+  private
+
+  def require_user_ids
+    redirect_back(fallback_location: root_path, danger: 'パラメータが不正です') if params.dig(:chatroom, :user_ids).reject(&:blank?).blank?
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,53 @@
+class MessagesController < ApplicationController
+  before_action :require_login, only: %i[create]
+  def create
+    @message = current_user.messages.build(message_params)
+    if @message.save
+      ActionCable.server.broadcast(
+        "chatroom_#{@message.chatroom_id}",
+        type: :create, html: (render_to_string partial: 'message', locals: { message: @message }, layout: false), message: @message.as_json
+      )
+      head :ok
+    else
+      head :bad_request
+    end
+  end
+
+  def edit
+    @message = current_user.messages.find(params[:id])
+  end
+
+  def update
+    @message = current_user.messages.find(params[:id])
+    if @message.update(message_update_params)
+      ActionCable.server.broadcast(
+        "chatroom_#{@message.chatroom_id}",
+        type: :update, html: (render_to_string partial: 'message', locals: { message: @message }, layout: false), message: @message.as_json
+      )
+      head :ok
+    else
+      head :bad_request
+    end
+  end
+
+  def destroy
+    @message = current_user.messages.find(params[:id])
+    @message.destroy!
+
+    ActionCable.server.broadcast(
+      "chatroom_#{@message.chatroom_id}",
+      type: :delete, html: (render_to_string partial: 'message', locals: { message: @message }, layout: false), message: @message.as_json
+    )
+    head :ok
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:body).merge(chatroom_id: params[:chatroom_id])
+  end
+
+  def message_update_params
+    params.require(:message).permit(:body)
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -5,6 +5,8 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
+      # ActionCableでユーザーを特定するために必要
+      cookies.signed['user.id'] = current_user.id
       redirect_back_or_to posts_path, success: 'ログインしました'
     else
       flash.now[:danger] = 'ログインに失敗しました'
@@ -14,6 +16,7 @@ class UserSessionsController < ApplicationController
 
   def destroy
     logout
+    cookies.delete('user.id')
     redirect_to login_path, success: 'ログアウトしました'
   end
 end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,0 +1,8 @@
+class ApplicationDecorator < Draper::Decorator
+  # Define methods for all decorated objects.
+  # Helpers are accessed through `helpers` (aka `h`). For example:
+  #
+  #   def percent_amount
+  #     h.number_to_percentage object.amount, precision: 2
+  #   end
+end

--- a/app/decorators/chatroom_decorator.rb
+++ b/app/decorators/chatroom_decorator.rb
@@ -1,0 +1,7 @@
+class ChatroomDecorator < ApplicationDecorator
+  delegate_all
+
+  def message_text
+    messages.last&.body&.truncate(30) || 'まだメッセージがありません'
+  end
+end

--- a/app/decorators/message_decorator.rb
+++ b/app/decorators/message_decorator.rb
@@ -1,0 +1,13 @@
+class MessageDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/decorators/message_decorator.rb
+++ b/app/decorators/message_decorator.rb
@@ -1,13 +1,8 @@
 class MessageDecorator < ApplicationDecorator
   delegate_all
-
-  # Define presentation-specific methods here. Helpers are accessed through
-  # `helpers` (aka `h`). You can override attributes, for example:
-  #
-  #   def created_at
-  #     helpers.content_tag :span, class: 'time' do
-  #       object.created_at.strftime("%a %m/%d/%y")
-  #     end
-  #   end
-
+  def created_at
+    helpers.tag.span(class: 'time') do
+      object.created_at.strftime('%Y-%m-%d %H:%M:%S')
+    end
+  end
 end

--- a/app/models/chatroom.rb
+++ b/app/models/chatroom.rb
@@ -1,0 +1,11 @@
+# == Schema Information
+#
+# Table name: chatrooms
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Chatroom < ApplicationRecord
+end

--- a/app/models/chatroom.rb
+++ b/app/models/chatroom.rb
@@ -7,5 +7,25 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+
 class Chatroom < ApplicationRecord
+  has_many :chatroom_users, dependent: :destroy
+  has_many :users, through: :chatroom_users
+  has_many :messages, dependent: :destroy
+
+  def self.chatroom_for_users(users)
+    user_ids = users.map(&:id).sort
+    name = user_ids.join(':').to_s
+
+    unless (chatroom = find_by(name: name))
+      chatroom = new(name: name)
+      chatroom.users = users
+      chatroom.save
+    end
+    chatroom
+  end
+
+  def users_excluding(user)
+    users.reject { |u| u == user }
+  end
 end

--- a/app/models/chatroom_user.rb
+++ b/app/models/chatroom_user.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: chatroom_users
+#
+#  id           :bigint           not null, primary key
+#  datetime     :datetime
+#  last_read_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  chatroom_id  :bigint
+#  user_id      :bigint
+#
+# Indexes
+#
+#  index_chatroom_users_on_chatroom_id              (chatroom_id)
+#  index_chatroom_users_on_user_id                  (user_id)
+#  index_chatroom_users_on_user_id_and_chatroom_id  (user_id,chatroom_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (chatroom_id => chatrooms.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class ChatroomUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :chatroom
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: messages
+#
+#  id          :bigint           not null, primary key
+#  body        :text(65535)      not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  chatroom_id :bigint
+#  user_id     :bigint
+#
+# Indexes
+#
+#  index_messages_on_chatroom_id  (chatroom_id)
+#  index_messages_on_user_id      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (chatroom_id => chatrooms.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :chatroom
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,9 @@ class User < ApplicationRecord
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
   has_many :activities, dependent: :destroy
+  has_many :chatroom_users, dependent: :destroy
+  has_many :chatrooms, through: :chatroom_users
+  has_many :messages, dependent: :destroy
 
   scope :recent, ->(count) { order(created_at: :desc).limit(count) }
 

--- a/app/views/chatrooms/_chatroom.html.slim
+++ b/app/views/chatrooms/_chatroom.html.slim
@@ -1,0 +1,6 @@
+.chatroom.mb-3.d-flex
+  = image_tag chatroom.users_excluding(current_user).sample.avatar_url, size: '40x40', class: 'rounded-circle mr-1'
+  div
+    p.font-weight-bold = raw(chatroom.users_excluding(current_user).map { |user| (link_to(user.username, user_path(user)))}.join(','))
+    p.font-weight-light = link_to chatroom.decorate.message_text, chatroom_path(chatroom)
+hr

--- a/app/views/chatrooms/index.html.slim
+++ b/app/views/chatrooms/index.html.slim
@@ -1,0 +1,40 @@
+.container
+  .text-center.mb-3
+    = link_to 'チャットルームを作る', '#', class: 'btn btn-primary btn-raised', data: { toggle: 'modal', target: '#create-chatroom-modal'}
+  .row
+    .col-md-6.col-12.offset-md-3.mb-3
+      .card
+        .card-body
+          = render(@chatrooms) || 'まだありません'
+    .col-md-6.col-12.offset-md-3
+      = paginate @chatrooms
+#create-chatroom-modal.modal.fade tabindex="-1"
+  = form_with model: Chatroom.new, local: true do |f|
+    - if current_user.following.present?
+      .modal-dialog
+        .modal-content
+          .modal-header
+            h5.modal-title 誰とのチャットルームを作りますか？
+            button.close aria-label="Close" data-dismiss="modal" type="button"
+              span aria-hidden="true"  ×
+          .modal-body
+            ul.list-unstyled
+
+              = f.collection_check_boxes :user_ids, current_user.following, :id, :username do |b|
+                .mb-3
+                  = b.label do
+                    = b.check_box class: 'mr-1'
+                    = image_tag b.object.avatar.url, size: '40x40', class: 'rounded-circle mr-1'
+                    = b.text
+          .modal-footer.text-center
+            = f.submit '作成', class: 'btn btn-primary btn-raised'
+    - else
+      .modal-dialog
+        .modal-content
+          .modal-header
+            h5.modal-title フォロワーがいません。
+            button.close aria-label="Close" data-dismiss="modal" type="button"
+              span aria-hidden="true"  ×
+          .modal-body
+            h5.h5 おすすめユーザー
+            = link_to 'ユーザー一覧', users_path, class: 'btn btn-primary btn-raised'

--- a/app/views/chatrooms/show.html.slim
+++ b/app/views/chatrooms/show.html.slim
@@ -1,0 +1,21 @@
+.container
+  .row
+    .col-sm-8.offset-sm-2
+      .card#chatroom data-chatroom-id="#{@chatroom.id}" data-current-user-id="#{current_user.id}"
+        .card-header
+          h2 チャットルーム
+          = link_to '参加者一覧', '#', class: 'btn btn-primary btn-raised', data: { toggle: 'modal', target: '#chatroom-users'}
+        .card-body
+          ul.list-unstyled#message-box
+            = render @chatroom.messages
+          = render 'messages/form', chatroom: @chatroom, message: @message ||= Message.new
+#chatroom-users.modal.fade tabindex="-1"
+  .modal-dialog
+    .modal-content
+      .modal-header
+        h5.modal-title 参加者
+        button.close aria-label="Close" data-dismiss="modal" type="button"
+          span aria-hidden="true"  ×
+      .modal-body
+        = render @chatroom.users
+      .modal-footer.text-center

--- a/app/views/messages/_form.html.slim
+++ b/app/views/messages/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: [chatroom, message], remote: true do |f|
+  = render 'shared/error_messages', object: message
+  = f.label :body
+  = f.text_field :body, class: 'form-control mb-3 input-message-body', required: true
+  - if message.new_record?
+    = f.submit '投稿', class: 'btn btn-primary btn-raised'
+  - else
+    = f.submit '更新', class: 'btn btn-primary btn-raised'

--- a/app/views/messages/_message.html.slim
+++ b/app/views/messages/_message.html.slim
@@ -1,0 +1,16 @@
+li.media.mb-3.border-bottom.p-2 id="message-#{message.id}" data-sender-id="#{message.user.id}"
+  div
+    div
+      = link_to message.user.username, user_path(message.user)
+    = image_tag message.user.avatar_url, class: 'mr-3 rounded-circle', size: '50x50'
+
+  .media-body
+    = simple_format(message.body)
+    div.text-right
+      = message.decorate.created_at
+    div.text-right.crud-area
+      - if current_user&.own?(message)
+        = link_to message_path(message), class: 'mr-3 delete-button', method: :delete, data: {confirm: '本当に削除しますか？'}, remote: true do
+          = icon 'far', 'trash-alt', class: 'fa-sm'
+        = link_to edit_message_path(message), class: 'edit-button', remote: true do
+          = icon 'far', 'edit', class: 'fa-sm'

--- a/app/views/messages/_modal_form.html.slim
+++ b/app/views/messages/_modal_form.html.slim
@@ -1,0 +1,9 @@
+.modal#message-edit-modal
+  .modal-dialog
+    .modal-content
+      .modal-header
+        h5.modal-title メッセージ編集
+        button.close aria-label="Close" data-dismiss="modal" type="button"
+          span aria-hidden="true"  ×
+      .modal-body
+        = render 'form', chatroom: nil, message: @message

--- a/app/views/messages/edit.js.slim
+++ b/app/views/messages/edit.js.slim
@@ -1,0 +1,2 @@
+| $("#modal-container").html("#{escape_javascript(render 'modal_form', message: @message)}");
+| $("#message-edit-modal").modal('show');

--- a/app/views/users/_message_button.html.slim
+++ b/app/views/users/_message_button.html.slim
@@ -1,0 +1,3 @@
+= form_with url: chatrooms_path, local: true do |f|
+  = f.hidden_field 'chatroom[user_ids][]', value: user.id
+  = f.submit 'メッセージ', class: 'btn btn-warning btn-raised'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -12,6 +12,9 @@
             = @user.username
           .text-center
             = render 'follow_area', user: @user
+          - if current_user && current_user&.id != @user.id
+            .text-center
+              = render 'message_button', user: @user
           hr
           .row
             = render partial: 'posts/thumbnail_post', collection: @user.posts

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,8 @@ ja:
     models:
       user: 'ユーザー'
       post: '投稿'
+      comment: 'コメント'
+      message: 'メッセージ'
     attributes:
       user:
         email: 'メールアドレス'
@@ -16,7 +18,13 @@ ja:
       post:
         images: '画像'
         body: '本文'
-        
+      comment:
+        body: 'コメント'
+        user_id: 'ユーザー'
+        post_id: '投稿'
+      message:
+        body: 'メッセージ'
+
   attributes:
     id: 'ID'
     created_at: '作成日時'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,11 @@ Rails.application.routes.draw do
     mount Sidekiq::Web, at: '/sidekiq'
   end
   root 'posts#index'
+
+  get 'login', to: 'user_sessions#new'
+  post 'login', to: 'user_sessions#create'
+  delete 'logout', to: 'user_sessions#destroy'
+
   resources :users, only: %i[index new create show]
   resources :posts, shallow: true do
     collection do
@@ -19,13 +24,13 @@ Rails.application.routes.draw do
     patch :read, on: :member
   end
 
+  resources :chatrooms, only: %i[index create show], shallow: true do
+    resources :messages
+  end
+
   namespace :mypage do
     resource :account, only: %i[edit update]
     resources :activities, only: %i[index]
     resource :notification_setting, only: %i[edit update]
   end
-
-  get 'login', to: 'user_sessions#new'
-  post 'login', to: 'user_sessions#create'
-  delete 'logout', to: 'user_sessions#destroy'
 end

--- a/db/migrate/20201011153202_create_chatrooms.rb
+++ b/db/migrate/20201011153202_create_chatrooms.rb
@@ -1,0 +1,8 @@
+class CreateChatrooms < ActiveRecord::Migration[5.2]
+  def change
+    create_table :chatrooms do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201012124008_create_chatroom_users.rb
+++ b/db/migrate/20201012124008_create_chatroom_users.rb
@@ -1,0 +1,13 @@
+class CreateChatroomUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :chatroom_users do |t|
+      t.references :user, foreign_key: true
+      t.references :chatroom, foreign_key: true
+      t.datetime :last_read_at, :datetime
+
+      t.timestamps
+    end
+
+    add_index :chatroom_users, [:user_id, :chatroom_id], unique: true
+  end
+end

--- a/db/migrate/20201012131252_create_messages.rb
+++ b/db/migrate/20201012131252_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :messages do |t|
+      t.references :user, foreign_key: true
+      t.references :chatroom, foreign_key: true
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_11_153202) do
+ActiveRecord::Schema.define(version: 2020_10_12_124008) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "subject_type"
@@ -22,6 +22,18 @@ ActiveRecord::Schema.define(version: 2020_10_11_153202) do
     t.datetime "updated_at", null: false
     t.index ["subject_type", "subject_id"], name: "index_activities_on_subject_type_and_subject_id"
     t.index ["user_id"], name: "index_activities_on_user_id"
+  end
+
+  create_table "chatroom_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "chatroom_id"
+    t.datetime "last_read_at"
+    t.datetime "datetime"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chatroom_id"], name: "index_chatroom_users_on_chatroom_id"
+    t.index ["user_id", "chatroom_id"], name: "index_chatroom_users_on_user_id_and_chatroom_id", unique: true
+    t.index ["user_id"], name: "index_chatroom_users_on_user_id"
   end
 
   create_table "chatrooms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -85,6 +97,8 @@ ActiveRecord::Schema.define(version: 2020_10_11_153202) do
   end
 
   add_foreign_key "activities", "users"
+  add_foreign_key "chatroom_users", "chatrooms"
+  add_foreign_key "chatroom_users", "users"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_12_124008) do
+ActiveRecord::Schema.define(version: 2020_10_12_131252) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "subject_type"
@@ -62,6 +62,16 @@ ActiveRecord::Schema.define(version: 2020_10_12_124008) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "chatroom_id"
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chatroom_id"], name: "index_messages_on_chatroom_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "body"
     t.string "images"
@@ -103,5 +113,7 @@ ActiveRecord::Schema.define(version: 2020_10_12_124008) do
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "messages", "chatrooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_073801) do
+ActiveRecord::Schema.define(version: 2020_10_11_153202) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "subject_type"
@@ -22,6 +22,12 @@ ActiveRecord::Schema.define(version: 2020_10_09_073801) do
     t.datetime "updated_at", null: false
     t.index ["subject_type", "subject_id"], name: "index_activities_on_subject_type_and_subject_id"
     t.index ["user_id"], name: "index_activities_on_user_id"
+  end
+
+  create_table "chatrooms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id         :bigint           not null, primary key
+#  body       :text(65535)
+#  images     :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_posts_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :post do
     body { Faker::Hacker.say_something_smart }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :bigint           not null, primary key
+#  avatar                  :string(255)
+#  crypted_password        :string(255)
+#  email                   :string(255)      not null
+#  notification_on_comment :boolean          default(TRUE)
+#  notification_on_follow  :boolean          default(TRUE)
+#  notification_on_like    :boolean          default(TRUE)
+#  salt                    :string(255)
+#  username                :string(255)      not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email     (email) UNIQUE
+#  index_users_on_username  (username) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.unique.email }

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id         :bigint           not null, primary key
+#  body       :text(65535)
+#  images     :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_posts_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                      :bigint           not null, primary key
+#  avatar                  :string(255)
+#  crypted_password        :string(255)
+#  email                   :string(255)      not null
+#  notification_on_comment :boolean          default(TRUE)
+#  notification_on_follow  :boolean          default(TRUE)
+#  notification_on_like    :boolean          default(TRUE)
+#  salt                    :string(255)
+#  username                :string(255)      not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email     (email) UNIQUE
+#  index_users_on_username  (username) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe User, type: :model do

--- a/spec/system/chartrooms_spec.rb
+++ b/spec/system/chartrooms_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'チャット', type: :system do
+  let(:login_user) { create(:user) }
+  let(:user) { create(:user) }
+  # OJT課題用なのでdescribeやcontextも書かない方がわかりやすいと思ったのであえてそうしている。
+
+  it 'ユーザーの詳細ページに「メッセージ」ボタンが存在すること' do
+    # ログインする
+    login_as login_user
+    # ユーザーの詳細画面に遷移する
+    visit user_path(user)
+    # メッセージボタンが存在する
+    expect(page).to have_selector(:link_or_button, 'メッセージ')
+  end
+
+  it '「メッセージ」ボタンを押すと当該ユーザーとのチャットルームに遷移すること' do
+    # ログインする
+    login_as login_user
+    # ユーザーの詳細画面に遷移する
+    visit user_path(user)
+    # メッセージボタンを押す
+    click_on 'メッセージ'
+    expect(current_path).to eq chatroom_path(Chatroom.first)
+  end
+
+  it 'テキストを入力して投稿ボタンを押すとメッセージが投稿されること' do
+    # ログインする
+    login_as login_user
+    # ユーザーの詳細画面に遷移する
+    visit user_path(user)
+    # メッセージボタンを押す
+    click_on 'メッセージ'
+    # メッセージを入力する
+    fill_in 'メッセージ', with: 'hello world'
+    # 投稿ボタンを押す
+    click_on '投稿'
+    # メッセージが画面に反映される
+    expect(page).to have_content 'hello world'
+  end
+
+  it 'コメントの編集ボタンを押すとモーダルが表示されコメントの更新ができること', js: true do
+    # ログインする
+    login_as login_user
+    # ユーザーの詳細画面に遷移する
+    visit user_path(user)
+    # メッセージボタンを押す
+    click_on 'メッセージ'
+    # メッセージを入力する
+    fill_in 'メッセージ', with: 'hello world'
+    # 投稿ボタンを押す
+    click_on '投稿'
+    # メッセージが画面に反映される
+    expect(page).to have_content 'hello world'
+    # メッセージの編集ボタンを押す
+    find(".edit-button").click
+    within '#modal-container' do
+      fill_in 'メッセージ', with: 'updated hello world'
+      click_on '更新'
+    end
+    expect(page).to have_content('updated hello world')
+  end
+
+  it 'コメントの削除ボタンを押すと確認ダイアログが出て「OK」を押すとコメントが削除されて画面から消えること' do
+    # ログインする
+    login_as login_user
+    # ユーザーの詳細画面に遷移する
+    visit user_path(user)
+    # メッセージボタンを押す
+    click_on 'メッセージ'
+    # メッセージを入力する
+    fill_in 'メッセージ', with: 'hello world'
+    # 投稿ボタンを押す
+    click_on '投稿'
+    # メッセージが画面に反映される
+    expect(page).to have_content 'hello world'
+    # メッセージの編集ボタンを押す
+    page.accept_confirm { find(".delete-button").click }
+    expect(page).not_to have_content('hello world')
+  end
+end


### PR DESCRIPTION
## 内容
- グループチャット機能を実装した
- 二人〜何人までも参加できる要件にした（→ グループチャットということ）
- ユーザーの詳細画面に「メッセージ」というボタンを配置し、それを押すとそのユーザーとのチャットルームに遷移するようにした
- チャットルームの一覧画面にはチャットルームの情報を表示している。内容は以下の通り。
  - チャットルームに参加しているユーザーのうち、自分以外のユーザーを一人ランダムで抽出し、そのユーザーのアバターを表示する（本当はチャットルームに画像を設定できるようにするべきだが内容がボリューミーになってしまうので妥協）
  - チャットルームに参加しているユーザーのうち、自分以外のユーザーの名前を`,`で区切ったもの。
  - 最新のメッセージ
  - 要はLINEのようなイメージ
- チャットルーム一覧画面にはグループチャットを開始できるボタンを追加した
  - ボタンを押すとモーダルが表示され、そのモーダルにはフォロワーの一覧が出てくるようにした
  - グループチャットを開始したいユーザーのチェックボックスをチェックして「作成」を押すとそのユーザーが参加しているチャットルームが作成されるようにした

- 今後、余裕があれば通知機能も作ってみる
  - 自分が参加しているチャットにメッセージがあったとき
    - xxx（リンク）からメッセージが来ています
    - 通知そのものに対してはxxxへのリンクを張る
- メッセージに対する既読管理もするとより本格的になる
- 未読状態が10分以上続く場合は「メッセージを見逃しています」というメールをユーザーに送る機能もつければもう本当のプロダクション
- ActionCableを使ってリアルタイムにチャットの投稿、編集、削除が他のユーザーのブラウザにも反映されるようにした

## 補足


Chatroomsテーブル
|id | name |
| ------------- | ------------- |
| 1  | 1:4  |
| 2  | 1:10:15:18  |

→ 「誰がどのチャットに参加しているか」は下記のChatroomUsersテーブルで表現できるが、それだけだとSQLがかなり複雑になるので参加しているユーザーのidを`:`で繋げた形で非正規形にデータを持たせることにした。上の例だとユーザーID1と4のユーザーがチャットルーム1に所属している。ユーザーID1,10,15,18のユーザーがチャットルーム2に所属している。ということを表現

ChatroomUsersテーブル
|id | user_id | chatroom_id |
| ------------- | ------------- | ------------- |
| 1 | 1 | 1 |
| 2 | 2 | 1 |
| 3 | 3 | 1 |
| 4 | 1 | 2 |
| 5 | 10 | 2 |

Messagesテーブル
|id | user_id | chatroom_id | body |
| ------------- | ------------- | ------------- | ------------- |
| 1 | 1 | 1 | Nice to meet you |
| 2 | 2 | 1 | Nice to meet you, too |
